### PR TITLE
Fix CI badge in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ ifdef::env-github[]
 endif::[]
 
 == Status 
-image:https://github.com/isaqb-org/curriculum-embedded/workflows/CI/badge.svg?branch=master["CI"]
+image:https://github.com/isaqb-org/curriculum-embedded/workflows/CI%20-%20Releases%20and%20Master/badge.svg["CI - Releases and Master"]
 image:https://img.shields.io/github/last-commit/isaqb-org/curriculum-embedded/master.svg["Last commit"]
 image:https://img.shields.io/github/contributors/isaqb-org/curriculum-embedded.svg["Contributors",link="https://github.com/isaqb-org/curriculum-embedded/graphs/contributors"]
 image:https://img.shields.io/github/issues/isaqb-org/curriculum-embedded.svg["Issues",link="https://github.com/isaqb-org/curriculum-embedded/issues"]


### PR DESCRIPTION
The CI Badge in the README currently links to a in the meantime renamed GitHub Action/Workflow.
The badge now links to the workflow [CI - Releases and Master](https://github.com/isaqb-org/curriculum-embedded/actions?query=workflow%3A%22CI+-+Releases+and+Master%22) defined in [this yml file](https://github.com/isaqb-org/curriculum-embedded/blob/master/.github/workflows/build_releasecandidate.yml)